### PR TITLE
Switch out yaml.load() for yaml.safe_load() (CVE-2017-18342)

### DIFF
--- a/scripts/courses.py
+++ b/scripts/courses.py
@@ -10,7 +10,7 @@ class Course():
         self.path = path
         self.name = path.stem
 
-        self.info = yaml.load((path / 'info.yaml').open())
+        self.info = yaml.safe_load((path / 'info.yaml').open())
         self._lectures = None
 
     @property


### PR DESCRIPTION
load() has had a security issue for a long time and safe_load() is completely satisfactory for this case.